### PR TITLE
Fix import paths of `dayjs` plugins

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -21,11 +21,14 @@ jobs:
           node-version-file: '.node-version'
           cache: 'pnpm'
 
-      - name: Install dependencies
-        run: make install
+      - name: Install dependencies & build application
+        run: make
 
       - name: Lint & format
         run: make lint
 
       - name: Run tests
         run: make test
+
+      - name: Confirm no error
+        run: make version

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,6 @@ lint:
 
 format:
 	pnpm format
+
+version:
+	pnpm exec node $(BUILD_DIR)/index.js --version

--- a/src/account.test.ts
+++ b/src/account.test.ts
@@ -8,6 +8,11 @@ import { AWSConfig } from './config';
 import { mockClient } from 'aws-sdk-client-mock';
 import AWSMock from 'aws-sdk-mock';
 
+jest.mock('./logger', () => ({
+  ...jest.requireActual('./logger'),
+  showSpinner: jest.fn(),
+}));
+
 describe('getAccountAlias', () => {
   const organizationsMock = mockClient(OrganizationsClient);
 

--- a/src/cost.test.ts
+++ b/src/cost.test.ts
@@ -11,6 +11,11 @@ const costDataLength = 65;
 const fixedToday = '2024-05-11'; // cost of 'this month' will be sum of 10 days from May 1 to May 10 ('today' is omitted because its cost is incomplete)
 const fixedFirstDay = dayjs(fixedToday).subtract(costDataLength, 'day');
 
+jest.mock('./logger', () => ({
+  ...jest.requireActual('./logger'),
+  showSpinner: jest.fn(),
+}));
+
 describe('Cost Functions', () => {
   beforeAll(() => {
     AWSMock.setSDKInstance(AWS);

--- a/src/cost.ts
+++ b/src/cost.ts
@@ -1,7 +1,7 @@
 import AWS from 'aws-sdk';
 import dayjs from 'dayjs';
-import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
-import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter.js';
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore.js';
 dayjs.extend(isSameOrAfter);
 dayjs.extend(isSameOrBefore);
 import { AWSConfig } from './config';

--- a/src/printers/slack.test.ts
+++ b/src/printers/slack.test.ts
@@ -17,6 +17,11 @@ const awsConfig: AWSConfig = {
   region: 'us-east-1',
 };
 
+jest.mock('../logger', () => ({
+  ...jest.requireActual('../logger'),
+  showSpinner: jest.fn(),
+}));
+
 const mockedCostByService = generateMockedCostByService(
   fixedToday,
   costDataLength,


### PR DESCRIPTION
close #8

the runtime error was reproduced by https://github.com/route06/aws-cost-cli/pull/23/commits/8a4c8e46e3a12ecd3229d015ad2a3f4a5cce32e5 and resolved by 