### PR TITLE
Resolve runtime error due to fails in loading ESmodules

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -21,11 +21,14 @@ jobs:
           node-version-file: '.node-version'
           cache: 'pnpm'
 
-      - name: Install dependencies
-        run: make install
+      - name: Install dependencies & build application
+        run: make
 
       - name: Lint & format
         run: make lint
 
       - name: Run tests
         run: make test
+
+      - name: Confirm no error
+        run: make version

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,6 @@ lint:
 
 format:
 	pnpm format
+
+version:
+	pnpm exec node $(BUILD_DIR)/index.js --version

--- a/src/cost.ts
+++ b/src/cost.ts
@@ -1,7 +1,7 @@
 import AWS from 'aws-sdk';
 import dayjs from 'dayjs';
-import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
-import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter.js';
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore.js';
 dayjs.extend(isSameOrAfter);
 dayjs.extend(isSameOrBefore);
 import { AWSConfig } from './config';


### PR DESCRIPTION
this PR closes #8 by importing `dayjs` plugins as ESmodules to resolve runtime error

the error was:
- reproduced on https://github.com/route06/aws-cost-cli/pull/25/commits/3517c0fa4161038b6a8845907bc049c2d12fb0bf
- resolved by https://github.com/route06/aws-cost-cli/pull/25/commits/aae0c9dc2da0c964cb1c9d4ddd78aeb4b2f1e420

